### PR TITLE
chore(report): Remove the status for the package metrics report

### DIFF
--- a/coverage-metrics/bin/utils/package-metrics/compare.py
+++ b/coverage-metrics/bin/utils/package-metrics/compare.py
@@ -3,7 +3,6 @@
 from argparse import ArgumentParser
 import json
 from prettytable import PrettyTable
-import os
 
 COLOURS = {
     "red": "\033[91m",
@@ -60,7 +59,6 @@ if "__main__" == __name__:
 
     table = PrettyTable(("Package", "Efferent", "Afferent", "External"))
 
-    status = os.EX_OK
     for pkg, pkg_metrics in target.items():
         is_new = pkg not in base
 
@@ -73,7 +71,8 @@ if "__main__" == __name__:
         external_label = " %+d" % delta_external if delta_external != 0 else ""
 
         if not is_new and any(delta > 0 for delta in [delta_efferent, delta_afferent, delta_external]):
-            status = os.EX_DATAERR
+            # Notify that the metrics increased for some packages.
+            pass
 
         table.add_row(
             (pkg,
@@ -87,5 +86,4 @@ if "__main__" == __name__:
     table.align["Afferent"] = "r"
     table.align["External"] = "r"
     print(table)
-
-    exit(status)
+    exit(0)


### PR DESCRIPTION
**Description**

Remove returning of the erroneous status for the package metrics report.

**Reasoning**
if the GitHub Action that generates the aforementioned report results in an error status, that prevents the PR form the automatic merging.